### PR TITLE
Change llTime to type time_t

### DIFF
--- a/dump1090.c
+++ b/dump1090.c
@@ -757,7 +757,7 @@ MODES_DUMP1090_VARIANT " " MODES_DUMP1090_VERSION
 
 #ifdef _WIN32
 void showCopyright(void) {
-    uint64_t llTime = time(NULL) + 1;
+    time_t llTime = time(NULL) + 1;
 
     printf(
 "-----------------------------------------------------------------------------\n"


### PR DESCRIPTION
When compiling I got an error with time(NULL) being a different type than the uint64_t llTime variable on line 782.

time(NULL) returns time_t so changing llTime will fix the error.
